### PR TITLE
docs(FeatureGroup要素组): 更新继承关系的说明。

### DIFF
--- a/reference-1.8.0.html
+++ b/reference-1.8.0.html
@@ -14973,7 +14973,7 @@ var circle = L.circle( center, { renderer: myRenderer } );
 </section>
 <h2>FeatureGroup 要素组</h2>
 <div class="ghost-pointer" id="featuregroup"></div>
-<p>扩展的 <a href="#layergroup"><code>图层</code></a> ，使它更容易对其所有成员图层做同样的事情:</p>
+<p>扩展的 <a href="#layergroup"><code>LayerGroup</code></a> ，使它更容易对其所有成员图层做同样的事情:</p>
 <ul>
     <li><a href="#layer-bindpopup"><code>bindPopup</code></a> 一次将一个弹出窗口绑定到所有的图层上 (与 <a href="#layer-bindtooltip"><code>bindTooltip</code></a>类似)</li>
     <li>事件被传递到 <a href="#featuregroup"><code>FeatureGroup</code></a>，所以如果该组有一个事件处理程序，它将处理来自任何图层的事件。这包括鼠标事件和自定义事件。</li>


### PR DESCRIPTION
原文'图层'容易理解为layer，改为LayerGroup使继承关系更容易理解